### PR TITLE
Support video streams with crude URI detection

### DIFF
--- a/src/hiptext.cc
+++ b/src/hiptext.cc
@@ -250,12 +250,13 @@ int main(int argc, char** argv) {
   }
   string path = argv[1];
   string extension = GetExtension(path);
+  string uri_sig = "://"; // Given this string signature, assume that it's a video stream
   if (extension == "png") {
     artiste.PrintImage(LoadPNG(path));
   } else if (extension == "jpg" || extension == "jpeg") {
     artiste.PrintImage(LoadJPEG(path));
   } else if (extension == "mov" || extension == "mp4" || extension == "flv" ||
-             extension == "avi" || extension == "mkv") {
+             extension == "avi" || extension == "mkv" || path.find(uri_sig) != string::npos) {
     artiste.PrintMovie(Movie(path));
   } else {
     fprintf(stderr, "Unknown Filetype: %s\n", extension.data());

--- a/src/movie.cc
+++ b/src/movie.cc
@@ -15,6 +15,12 @@ extern "C" {  // ffmpeg hates C++ and won't put this in their headers.
 #include "hiptext/graphic.h"
 #include "hiptext/pixel.h"
 
+#if (LIBAVFORMAT_VERSION_INT) > AV_VERSION_INT(55, 16, 0)
+#define PIX_FMT_RGB24 AV_PIX_FMT_RGB24
+#define avcodec_alloc_frame() av_frame_alloc()
+#define av_free_packet(packet) av_packet_unref(packet)
+#endif
+
 Movie::Movie(const std::string& path) {
   format_ = avformat_alloc_context();
 


### PR DESCRIPTION
Compile against newer versions of ffmpeg, namely v3.0.1 Fixes #36